### PR TITLE
Fix permissions of ssh folder content on container start

### DIFF
--- a/root/etc/cont-init.d/50-perms
+++ b/root/etc/cont-init.d/50-perms
@@ -2,3 +2,7 @@
 
 chown -R abc:abc /config
 chown -R abc:abc /config/.ssh
+
+chmod 700 /config/.ssh
+chmod -R 600 /config/.ssh/*
+chmod -R 644 /config/.ssh/*.pub


### PR DESCRIPTION
Of course, the ssh key permissions _should_ already be correct when mounted as volume, but sometimes there are not. (For example when docker is run on Windows...)
Fixing the ssh permissions on container start is making life a little easier for the users of this project. For the rights, I oriented here: https://superuser.com/a/1559867